### PR TITLE
Get metadata of uploaded files

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -27,7 +27,7 @@ File Transfer
    :template: scitacean-class-template.rst
    :recursive:
 
-   transfer.ess.ESSTestFileTransfer
+   transfer.ssh.SSHFileTransfer
 
 Dataclasses
 ~~~~~~~~~~~

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -43,6 +43,7 @@ Breaking changes
 * A number of attributes of Dataset are now read only.
 * :meth:`Dataset.new` was removed, use the regular ``__init__`` method instead.
 * ``File.provide_locally`` was removed in favor of :meth:`Client.download_files`.
+* ``ESSTestFileTransfer`` was renamed to :class:`scitacean.transfer.ssh.SSHFileTransfer`.
 
 Bugfixes
 ~~~~~~~~

--- a/docs/user-guide/downloading.ipynb
+++ b/docs/user-guide/downloading.ipynb
@@ -12,10 +12,10 @@
     "\n",
     "```python\n",
     "from scitacean import Client\n",
-    "from scitacean.transfer.ess import ESSTestFileTransfer\n",
+    "from scitacean.transfer.ssh import SSHFileTransfer\n",
     "client = Client.from_token(url=\"https://scicat.ess.eu/api/v3\",\n",
     "                           token=...,\n",
-    "                           file_transfer=ESSTestFileTransfer(\n",
+    "                           file_transfer=SSHFileTransfer(\n",
     "                               host=\"login.esss.dk\"\n",
     "                           ))\n",
     "```\n",
@@ -40,7 +40,7 @@
     "</div>\n",
     "\n",
     "While the client itself is responsible for talking to SciCat, a `file_transfer` object is required to download data files.\n",
-    "Currently, only `ESSTestFileTransfer` is implemented.\n",
+    "Currently, only `SSHFileTransfer` is implemented.\n",
     "It downloads / uploads files via SSH.\n",
     "It will almost definitely change in the future!\n",
     "\n",
@@ -295,7 +295,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/downloading.ipynb
+++ b/docs/user-guide/downloading.ipynb
@@ -295,8 +295,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/installation.rst
+++ b/docs/user-guide/installation.rst
@@ -8,5 +8,5 @@ pip
 
     pip install scitacean[ssh]
 
-If :class:`scitacean.transfer.ess.ESSTestFileTransfer` is not required, the ``ssh`` extra can be omitted.
+If :class:`scitacean.transfer.ssh.SSHFileTransfer` is not required, the ``ssh`` extra can be omitted.
 

--- a/docs/user-guide/uploading.ipynb
+++ b/docs/user-guide/uploading.ipynb
@@ -12,15 +12,15 @@
     "We connect to SciCat and a file server using a [Client](../generated/classes/scitacean.Client.rst):\n",
     "```python\n",
     "from scitacean import Client\n",
-    "from scitacean.transfer.ess import ESSTestFileTransfer\n",
+    "from scitacean.transfer.ssh import SSHFileTransfer\n",
     "client = Client.from_token(url=\"https://scicat.ess.eu/api/v3\",\n",
     "                           token=...,\n",
-    "                           file_transfer=ESSTestFileTransfer(\n",
+    "                           file_transfer=SSHFileTransfer(\n",
     "                               host=\"login.esss.dk\",\n",
     "                               remote_base_path=\"/somewhere/on/remote/\"\n",
     "                           ))\n",
     "```\n",
-    "This code is identical to the one used for [downloading](./downloading.ipynb) except for the `remote_base_path` which tells `ESSTestFileTransfer` where to put our files.\n",
+    "This code is identical to the one used for [downloading](./downloading.ipynb) except for the `remote_base_path` which tells `SSHFileTransfer` where to put our files.\n",
     "\n",
     "As with the downloading guide, we use a fake client instead of the real one shown above."
    ]
@@ -269,7 +269,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/uploading.ipynb
+++ b/docs/user-guide/uploading.ipynb
@@ -269,8 +269,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/src/scitacean/client.py
+++ b/src/scitacean/client.py
@@ -561,7 +561,7 @@ class ScicatClient:
             err = response.json().get("error", {})
             logger.error("API call failed, endpoint: %s, response: %s", full_url, err)
             raise ScicatCommError(f"Error in operation {operation}: {err}")
-        logger.info("API call successful for operation '%s'")
+        logger.info("API call successful for operation '%s'", operation)
         return response.json()
 
 

--- a/src/scitacean/error.py
+++ b/src/scitacean/error.py
@@ -4,6 +4,10 @@
 """Exception classes."""
 
 
+class FileUploadError(RuntimeError):
+    """Raised when file upload fails."""
+
+
 class IntegrityError(RuntimeError):
     """Raised when a dataset or file is broken."""
 

--- a/src/scitacean/transfer/ssh.py
+++ b/src/scitacean/transfer/ssh.py
@@ -257,16 +257,15 @@ def _authenticated_connect(
 
 
 def _connect(host: str, port: Optional[int]) -> Connection:
-    # Catch all exceptions and remove traceback up to this point.
-    # We pass secrets as arguments to functions called in this block and those
-    # can be leaked through exception handlers.
     try:
         try:
             return _unauthenticated_connect(host, port)
         except AuthenticationException as exc:
             return _authenticated_connect(host, port, exc)
     except Exception as exc:
-        # TODO dedicated exception type?
+        # We pass secrets as arguments to functions called in this block and those
+        # can be leaked through exception handlers. So catch all exceptions
+        # and strip the backtrace up to this point to hide those secrets.
         raise type(exc)(exc.args) from None
     except BaseException as exc:
         raise type(exc)(exc.args) from None


### PR DESCRIPTION
Read metadata (UID, permission, etc.) of files after upload and write that to the database. Also adds validation of uploaded files.

Renamed `ESSTestFileTransfer` to `SSHFileTransfer` to make it more permanent. Going to add automated tests for it in a follow up PR. Checked manually that it works.

@SimonHeybrock Can you review, please?