### PR TITLE
Windows path handling

### DIFF
--- a/src/scitacean/_dataset_fields.py
+++ b/src/scitacean/_dataset_fields.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict, Generator, List, Literal, Optional, Unio
 import dateutil.parser
 
 from .datablock import OrigDatablockProxy
+from .filesystem import RemotePath
 from .model import (
     DatasetLifecycle,
     DatasetType,
@@ -424,7 +425,7 @@ class DatasetFields:
             read_only=False,
             required_by_derived=True,
             required_by_raw=True,
-            type=str,
+            type=RemotePath,
             used_by_derived=True,
             used_by_raw=True,
         ),
@@ -541,7 +542,7 @@ class DatasetFields:
         proposal_id: Optional[str] = None,
         sample_id: Optional[str] = None,
         shared_with: Optional[List[str]] = None,
-        source_folder: Optional[str] = None,
+        source_folder: Optional[RemotePath] = None,
         source_folder_host: Optional[str] = None,
         techniques: Optional[List[Technique]] = None,
         used_software: Optional[List[str]] = None,
@@ -871,12 +872,12 @@ class DatasetFields:
         self._fields["shared_with"] = val
 
     @property
-    def source_folder(self) -> Optional[str]:
+    def source_folder(self) -> Optional[RemotePath]:
         """Absolute file path on file server containing the files of this dataset, e.g. /some/path/to/sourcefolder. In case of a single file dataset, e.g. HDF5 data, it contains the path up to, but excluding the filename."""
         return self._fields["source_folder"]
 
     @source_folder.setter
-    def source_folder(self, val: Optional[str]):
+    def source_folder(self, val: Optional[RemotePath]):
         self._fields["source_folder"] = val
 
     @property

--- a/src/scitacean/client.py
+++ b/src/scitacean/client.py
@@ -653,7 +653,7 @@ def _file_selector(select: FileSelector) -> Callable[[File], bool]:
     if isinstance(select, (list, tuple)):
         return lambda f: f.remote_path in select
     if isinstance(select, re.Pattern):
-        return lambda f: select.search(f.remote_path) is not None
+        return lambda f: select.search(str(f.remote_path)) is not None
     return select
 
 

--- a/src/scitacean/datablock.py
+++ b/src/scitacean/datablock.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scitacean contributors (https://github.com/SciCatProject/scitacean)
 # @author Jan-Lukas Wynen
-# flake8: noqa
 
 """Wrappers for (Orig)Datablocks."""
 

--- a/src/scitacean/filesystem.py
+++ b/src/scitacean/filesystem.py
@@ -41,6 +41,9 @@ class RemotePath(os.PathLike):
     def __str__(self) -> str:
         return self._path
 
+    def __repr__(self) -> str:
+        return f"RemotePath({str(self)})"
+
     def __fspath__(self) -> str:
         """Return the file system representation of the path."""
         return str(self)

--- a/src/scitacean/filesystem.py
+++ b/src/scitacean/filesystem.py
@@ -51,10 +51,10 @@ class RemotePath(os.PathLike):
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, (RemotePath, str)):
             return False
-        return str(self) == str(other)
+        return self._path == RemotePath(other)._path
 
     def __hash__(self) -> int:
-        return hash(str(self))
+        return hash(self._path)
 
     @property
     def name(self) -> str:

--- a/src/scitacean/filesystem.py
+++ b/src/scitacean/filesystem.py
@@ -50,6 +50,9 @@ class RemotePath(os.PathLike):
             return False
         return str(self) == str(other)
 
+    def __hash__(self) -> int:
+        return hash(str(self))
+
     @property
     def name(self) -> str:
         """The name of the file with all directories removed."""

--- a/src/scitacean/filesystem.py
+++ b/src/scitacean/filesystem.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scitacean contributors (https://github.com/SciCatProject/scitacean)
+# @author Jan-Lukas Wynen
+"""Filesystem utilities.
+
+Local paths are stored as pathlib.Path
+Remote paths are stored as scitacean.filesystem.RemotePath
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable, Generator, Optional, Union
+
+
+class RemotePath(os.PathLike):
+    """A path on the remote filesystem.
+
+    Remote paths need not correspond to a regular filesystem path like
+    :class:`pathlib.PosixPath` or :class:`pathlib.WindowsPath`.
+    Instead, they can be any sequence of segments that are joined by forward slashes,
+    e.g. a URL.
+    """
+
+    def __init__(self, path: Union[str, RemotePath]):
+        self._path = os.fspath(path)
+
+    def __truediv__(self, other: Union[str, RemotePath]) -> RemotePath:
+        """Join two path segments."""
+        this = _strip_trailing_slash(os.fspath(self))
+        other = _strip_leading_slash(_strip_trailing_slash(os.fspath(other)))
+        return RemotePath(f"{this}/{other}")
+
+    def __rtruediv__(self, other: str) -> RemotePath:
+        """Join two path segments."""
+        return RemotePath(other) / self
+
+    def __str__(self) -> str:
+        return self._path
+
+    def __fspath__(self) -> str:
+        """Return the file system representation of the path."""
+        return str(self)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, (RemotePath, str)):
+            return False
+        return str(self) == str(other)
+
+    @property
+    def name(self) -> str:
+        """The name of the file with all directories removed."""
+        return self._path.rstrip("/").rsplit("/", 1)[-1]
+
+    @property
+    def suffix(self) -> Optional[str]:
+        """The file extension including a leading period."""
+        parts = self.name.rsplit(".", 1)
+        if len(parts) == 1:
+            return None
+        return "." + parts[1]
+
+    @classmethod
+    def __get_validators__(
+        cls,
+    ) -> Generator[Callable[[Union[str, RemotePath]], RemotePath], None, None]:
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value: Union[str, RemotePath]) -> RemotePath:
+        return RemotePath(value)
+
+
+def _strip_trailing_slash(s: str) -> str:
+    return s[:-1] if s.endswith("/") else s
+
+
+def _strip_leading_slash(s: str) -> str:
+    return s[1:] if s.startswith("/") else s

--- a/src/scitacean/filesystem.py
+++ b/src/scitacean/filesystem.py
@@ -9,7 +9,10 @@ Remote paths are stored as scitacean.filesystem.RemotePath
 
 from __future__ import annotations
 
+import hashlib
 import os
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Callable, Generator, Optional, Union
 
 
@@ -77,3 +80,30 @@ def _strip_trailing_slash(s: str) -> str:
 
 def _strip_leading_slash(s: str) -> str:
     return s[1:] if s.startswith("/") else s
+
+
+def file_size(path: Path) -> int:
+    return path.stat().st_size
+
+
+def file_modification_time(path: Path) -> datetime:
+    """Return the time in UTC when a file was last modified."""
+    return datetime.fromtimestamp(path.stat().st_mtime).astimezone(timezone.utc)
+
+
+def _new_hash(algorithm: str):
+    try:
+        return hashlib.new(algorithm, usedforsecurity=False)
+    except TypeError:
+        # Fallback for Python < 3.9
+        return hashlib.new(algorithm)
+
+
+# size based on http://git.savannah.gnu.org/gitweb/?p=coreutils.git;a=blob;f=src/ioblksize.h;h=ed2f4a9c4d77462f357353eb73ee4306c28b37f1;hb=HEAD#l23  # noqa: E501
+def checksum_of_file(path: Union[str, Path], *, algorithm: str) -> str:
+    chk = _new_hash(algorithm)
+    buffer = memoryview(bytearray(128 * 1024))
+    with open(path, "rb", buffering=0) as file:
+        for n in iter(lambda: file.readinto(buffer), 0):
+            chk.update(buffer[:n])
+    return chk.hexdigest()

--- a/src/scitacean/model.py
+++ b/src/scitacean/model.py
@@ -10,12 +10,14 @@
 """Pydantic models to encode data for communication with SciCat."""
 
 import enum
+import os
 from datetime import datetime
 from typing import Dict, List, Optional
 
 import pydantic
 
 from ._internal.orcid import is_valid_orcid
+from .filesystem import RemotePath
 from .pid import PID
 
 
@@ -30,7 +32,7 @@ class DatasetType(str, enum.Enum):
 class BaseModel(pydantic.BaseModel):
     class Config:
         extra = pydantic.Extra.forbid
-        json_encoders = {PID: lambda v: str(v)}
+        json_encoders = {PID: lambda v: str(v), RemotePath: lambda v: os.fspath(v)}
 
 
 class DatasetLifecycle(BaseModel):
@@ -103,7 +105,7 @@ class DerivedDataset(Ownable):
     inputDatasets: List[PID]
     investigator: str
     owner: str
-    sourceFolder: str
+    sourceFolder: RemotePath
     type: DatasetType
     usedSoftware: List[str]
     classification: Optional[str]
@@ -160,7 +162,7 @@ class RawDataset(Ownable):
     creationTime: datetime
     principalInvestigator: str
     owner: str
-    sourceFolder: str
+    sourceFolder: RemotePath
     type: DatasetType
     classification: Optional[str]
     creationLocation: Optional[str]

--- a/src/scitacean/typing.py
+++ b/src/scitacean/typing.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import ContextManager, List, Protocol
 
 from .file import File
+from .filesystem import RemotePath
 from .pid import PID
 
 
@@ -41,7 +42,7 @@ class UploadConnection(Protocol):
     """An open connection to the file server for uploads."""
 
     # TODO rename to source_folder (or remove?)
-    source_dir: str
+    source_dir: RemotePath
     """Files are uploaded to this directory / location."""
 
     def upload_files(self, *files: File) -> List[File]:

--- a/tests/common/backend.py
+++ b/tests/common/backend.py
@@ -1,6 +1,10 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scitacean contributors (https://github.com/SciCatProject/scitacean)
+# @author Jan-Lukas Wynen
+# flake8: noqa
+
 import json
 import shutil
-import subprocess
 import time
 from pathlib import Path
 from urllib.parse import urljoin
@@ -18,7 +22,7 @@ _SCICAT_ORIG_DATABLOCK_SEED_FILE = Path("seed_db/seed/OrigDatablock.json")
 
 # List of required services for tests.
 # We only need the backend and API to run tests.
-_SERVICES = ("catamel", "mongodb", "mongodb_seed", "reverse-proxy")
+SERVICES = ("catamel", "mongodb", "mongodb_seed", "reverse-proxy")
 
 
 def can_connect(scicat_access) -> bool:
@@ -56,28 +60,6 @@ def configure(target_dir) -> Path:
     _merge_seed_file(target, _SCICAT_ORIG_DATABLOCK_SEED_FILE, load_orig_datablocks())
 
     return target / _SCICAT_DOCKER_CONFIG.name
-
-
-def start_backend_containers(config_file):
-    # waiting for scicatlive-mongodb_seed-1 with recreate seems to deadlock
-    subprocess.check_call(
-        [
-            "docker",
-            "compose",
-            "--file",
-            config_file,
-            "up",
-            "--detach",
-            "--force-recreate",
-            *_SERVICES,
-        ]
-    )
-
-
-def stop_backend_containers(config_file):
-    subprocess.check_call(
-        ["docker", "compose", "--file", config_file, "down", "--volumes"]
-    )
 
 
 def skip_if_not_backend(request):

--- a/tests/common/backend.py
+++ b/tests/common/backend.py
@@ -50,6 +50,7 @@ def scicat_backend(request, scicat_access):
 
     if not request.config.getoption("--backend-tests"):
         yield False
+        return
 
     with tempfile.TemporaryDirectory() as temp_dir:
         config_file = configure(temp_dir)

--- a/tests/common/backend.py
+++ b/tests/common/backend.py
@@ -2,17 +2,20 @@
 # Copyright (c) 2022 Scitacean contributors (https://github.com/SciCatProject/scitacean)
 # @author Jan-Lukas Wynen
 # flake8: noqa
-
 import json
 import shutil
+import tempfile
 import time
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Dict, Union
 from urllib.parse import urljoin
 
 import pytest
 import requests
 
 from ..data import load_datasets, load_orig_datablocks
+from .docker import docker_compose
 
 _TEST_BASE = Path(__file__).resolve().parent.parent
 _SCICAT_DOCKER_CONFIG = _TEST_BASE / "scicatlive/docker-compose.yaml"
@@ -22,10 +25,41 @@ _SCICAT_ORIG_DATABLOCK_SEED_FILE = Path("seed_db/seed/OrigDatablock.json")
 
 # List of required services for tests.
 # We only need the backend and API to run tests.
-SERVICES = ("catamel", "mongodb", "mongodb_seed", "reverse-proxy")
+_SERVICES = ("catamel", "mongodb", "mongodb_seed", "reverse-proxy")
 
 
-def can_connect(scicat_access) -> bool:
+@dataclass
+class SciCatAccess:
+    url: str
+    functional_credentials: Dict[str, str]
+
+
+@pytest.fixture(scope="session")
+def scicat_access():
+    return SciCatAccess(
+        url="http://localhost/api/v3/",
+        functional_credentials={"username": "ingestor", "password": "aman"},
+    )
+
+
+@pytest.fixture(scope="session")
+def scicat_backend(request, scicat_access):
+    """Spin up a SciCat backend and API.
+
+    Does nothing unless the --backend-tests command line option is set.
+    """
+
+    if not request.config.getoption("--backend-tests"):
+        yield False
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config_file = configure(temp_dir)
+        with docker_compose(config_file, *_SERVICES):
+            wait_until_backend_is_live(scicat_access, max_time=20, n_tries=20)
+            yield True
+
+
+def can_connect(scicat_access: SciCatAccess) -> bool:
     response = requests.post(
         urljoin(scicat_access.url, "Users/login"),
         json=scicat_access.functional_credentials,
@@ -33,7 +67,9 @@ def can_connect(scicat_access) -> bool:
     return response.ok
 
 
-def wait_until_backend_is_live(scicat_access, max_time: float, n_tries: int):
+def wait_until_backend_is_live(
+    scicat_access: SciCatAccess, max_time: float, n_tries: int
+):
     """
     The containers take a while to be fully live.
     """
@@ -45,7 +81,9 @@ def wait_until_backend_is_live(scicat_access, max_time: float, n_tries: int):
         raise RuntimeError("Cannot connect to backend")
 
 
-def _merge_seed_file(target_dir, seed_file_name, custom_seed):
+def _merge_seed_file(
+    target_dir: Path, seed_file_name: Union[str, Path], custom_seed: Union[list, dict]
+):
     with open(target_dir / seed_file_name, "r") as f:
         dset_seed = json.load(f)
     dset_seed.extend(custom_seed)
@@ -53,7 +91,7 @@ def _merge_seed_file(target_dir, seed_file_name, custom_seed):
         json.dump(dset_seed, f)
 
 
-def configure(target_dir) -> Path:
+def configure(target_dir: Path) -> Path:
     target = Path(target_dir) / "scicatlive"
     shutil.copytree(_SCICAT_DOCKER_CONFIG.parent, target)
     _merge_seed_file(target, _SCICAT_DATASET_SEED_FILE, load_datasets())

--- a/tests/common/backend.py
+++ b/tests/common/backend.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scitacean contributors (https://github.com/SciCatProject/scitacean)
 # @author Jan-Lukas Wynen
-# flake8: noqa
 import json
 import shutil
 import tempfile

--- a/tests/common/docker.py
+++ b/tests/common/docker.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scitacean contributors (https://github.com/SciCatProject/scitacean)
+# @author Jan-Lukas Wynen
+# flake8: noqa
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+
+
+def docker_compose_up(config_file: Path, *services: str):
+    subprocess.check_call(
+        [
+            "docker",
+            "compose",
+            "--file",
+            str(config_file),
+            "up",
+            "--detach",
+            "--force-recreate",
+            *services,
+        ]
+    )
+
+
+def docker_compose_down(config_file: Path):
+    subprocess.check_call(
+        ["docker", "compose", "--file", str(config_file), "down", "--volumes"]
+    )
+
+
+@contextmanager
+def docker_compose(config_file: Path, *services: str):
+    docker_compose_up(config_file, *services)
+    try:
+        yield
+    finally:
+        docker_compose_down(config_file)

--- a/tests/common/docker.py
+++ b/tests/common/docker.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scitacean contributors (https://github.com/SciCatProject/scitacean)
 # @author Jan-Lukas Wynen
-# flake8: noqa
 import subprocess
 from contextlib import contextmanager
 from pathlib import Path

--- a/tests/common/ssh_server.py
+++ b/tests/common/ssh_server.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scitacean contributors (https://github.com/SciCatProject/scitacean)
+# @author Jan-Lukas Wynen
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import yaml
+
+from .docker import docker_compose
+
+_SSH_SERVER_DOCKER_CONFIG = (
+    Path(__file__).resolve().parent / "docker-compose-ssh-server.yaml"
+)
+
+
+@dataclass
+class SSHAccess:
+    host: str
+    port: int
+    username: str
+    password: str
+
+
+def _load_config() -> SSHAccess:
+    with open(_SSH_SERVER_DOCKER_CONFIG, "r") as f:
+        config = yaml.safe_load(f)
+    service = config["services"]["scitacean-test-ssh-server"]
+    env = {k: v for k, v in map(lambda s: s.split("="), service["environment"])}
+    return SSHAccess(
+        host="localhost",
+        port=service["ports"][0].split(":")[0],
+        username=env["USER_NAME"],
+        password=env["USER_PASSWORD"],
+    )
+
+
+@pytest.fixture(scope="session")
+def ssh_access():
+    return _load_config()
+
+
+@pytest.fixture(scope="session")
+def ssh_fileserver(request, ssh_access):
+    """Spin up an SSH server.
+
+    Does nothing unless the --ssh-tests command line option is set.
+    """
+
+    if not request.config.getoption("--ssh-tests"):
+        yield False
+
+    with docker_compose(_SSH_SERVER_DOCKER_CONFIG):
+        yield True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scitacean contributors (https://github.com/SciCatProject/scitacean)
+# @author Jan-Lukas Wynen
+# flake8: noqa
+
 import tempfile
 from dataclasses import dataclass
 from typing import Dict
@@ -6,6 +11,7 @@ import hypothesis
 import pytest
 
 from .common import backend
+from .common.docker import docker_compose
 
 # The datasets strategy requires a large amount of memory and time.
 # This is not good but hard to avoid.
@@ -38,14 +44,11 @@ def scicat_backend(request, scicat_access):
     if request.config.getoption("--backend-tests"):
         with tempfile.TemporaryDirectory() as temp_dir:
             config_file = backend.configure(temp_dir)
-            try:
-                backend.start_backend_containers(config_file)
+            with docker_compose(config_file, *backend.SERVICES):
                 backend.wait_until_backend_is_live(
                     scicat_access, max_time=20, n_tries=20
                 )
                 yield True
-            finally:
-                backend.stop_backend_containers(config_file)
     else:
         yield False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022 Scitacean contributors (https://github.com/SciCatProject/scitacean)
 # @author Jan-Lukas Wynen
-# flake8: noqa
 
 import hypothesis
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,15 +3,10 @@
 # @author Jan-Lukas Wynen
 # flake8: noqa
 
-import tempfile
-from dataclasses import dataclass
-from typing import Dict
-
 import hypothesis
 import pytest
 
-from .common import backend
-from .common.docker import docker_compose
+from .common.backend import scicat_access, scicat_backend  # noqa: F401
 
 # The datasets strategy requires a large amount of memory and time.
 # This is not good but hard to avoid.
@@ -25,43 +20,10 @@ hypothesis.settings.register_profile(
 )
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: pytest.Parser):
     parser.addoption(
         "--backend-tests",
         action="store_true",
         default=False,
         help="Select whether to run tests against a real SciCat backend",
-    )
-
-
-@pytest.fixture(scope="session")
-def scicat_backend(request, scicat_access):
-    """Spin up a SciCat backend and API.
-
-    Does nothing unless the --backend-tests command line option is set.
-    """
-
-    if request.config.getoption("--backend-tests"):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            config_file = backend.configure(temp_dir)
-            with docker_compose(config_file, *backend.SERVICES):
-                backend.wait_until_backend_is_live(
-                    scicat_access, max_time=20, n_tries=20
-                )
-                yield True
-    else:
-        yield False
-
-
-@dataclass
-class SciCatAccess:
-    url: str
-    functional_credentials: Dict[str, str]
-
-
-@pytest.fixture(scope="session")
-def scicat_access():
-    return SciCatAccess(
-        url="http://localhost/api/v3/",
-        functional_credentials={"username": "ingestor", "password": "aman"},
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import hypothesis
 import pytest
 
 from .common.backend import scicat_access, scicat_backend  # noqa: F401
+from .common.ssh_server import ssh_access, ssh_fileserver  # noqa: F401
 
 # The datasets strategy requires a large amount of memory and time.
 # This is not good but hard to avoid.
@@ -25,4 +26,10 @@ def pytest_addoption(parser: pytest.Parser):
         action="store_true",
         default=False,
         help="Select whether to run tests against a real SciCat backend",
+    )
+    parser.addoption(
+        "--ssh-tests",
+        action="store_true",
+        default=False,
+        help="Select whether to run tests with an SSH fileserver",
     )

--- a/tests/dataset_fields_test.py
+++ b/tests/dataset_fields_test.py
@@ -16,6 +16,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from scitacean import PID, Dataset, DatasetType
+from scitacean.filesystem import RemotePath
 from scitacean.model import DataFile, DerivedDataset, OrigDatablock, RawDataset
 
 
@@ -128,7 +129,7 @@ def test_init_from_models_sets_metadata():
             creationTime=dateutil.parser.parse("2022-01-10T11:14:52+02:00"),
             principalInvestigator="librarian@uu.am",
             owner="PonderStibbons",
-            sourceFolder="/hex/source91",
+            sourceFolder=RemotePath("/hex/source91"),
             type=DatasetType.RAW,
             ownerGroup="faculty",
             createdBy="pstibbons",
@@ -170,7 +171,7 @@ def test_init_from_models_sets_files():
             creationTime=dateutil.parser.parse("2022-01-10T11:14:52-01:00"),
             principalInvestigator="librarian@uu.am",
             owner="PonderStibbons",
-            sourceFolder="/hex/source91",
+            sourceFolder=RemotePath("/hex/source91"),
             type=DatasetType.RAW,
             ownerGroup="faculty",
         ),
@@ -200,13 +201,13 @@ def test_init_from_models_sets_files():
     assert dset.packed_size == 0
     assert dset.size == 6123 + 551
 
-    f0 = [f for f in dset.files if f.remote_path.endswith(".dat")][0]
+    f0 = [f for f in dset.files if f.remote_path.suffix == ".dat"][0]
     assert f0.remote_access_path(dset.source_folder) == "/hex/source91/file1.dat"
     assert f0.local_path is None
     assert f0.size == 6123
     assert f0.make_model().path == "file1.dat"
 
-    f1 = [f for f in dset.files if f.remote_path.endswith(".png")][0]
+    f1 = [f for f in dset.files if f.remote_path.suffix == ".png"][0]
     assert f1.remote_access_path(dset.source_folder) == "/hex/source91/sub/file2.png"
     assert f1.local_path is None
     assert f1.size == 551
@@ -219,7 +220,7 @@ def test_init_from_models_sets_files_multi_datablocks():
         creationTime=dateutil.parser.parse("2022-01-10T11:14:52-01:00"),
         principalInvestigator="librarian@uu.am",
         owner="PonderStibbons",
-        sourceFolder="/hex/source91",
+        sourceFolder=RemotePath("/hex/source91"),
         type=DatasetType.RAW,
         ownerGroup="faculty",
     )
@@ -256,13 +257,13 @@ def test_init_from_models_sets_files_multi_datablocks():
     assert dset.packed_size == 0
     assert dset.size == 6123 + 992
 
-    f0 = [f for f in dset.files if f.remote_path.endswith(".dat")][0]
+    f0 = [f for f in dset.files if f.remote_path.suffix == ".dat"][0]
     assert f0.remote_access_path(dset.source_folder) == "/hex/source91/file1.dat"
     assert f0.local_path is None
     assert f0.size == 6123
     assert f0.make_model().path == "file1.dat"
 
-    f1 = [f for f in dset.files if f.remote_path.endswith(".png")][0]
+    f1 = [f for f in dset.files if f.remote_path.suffix == ".png"][0]
     assert f1.remote_access_path(dset.source_folder) == "/hex/source91/sub/file2.png"
     assert f1.local_path is None
     assert f1.size == 992
@@ -302,7 +303,7 @@ def test_make_raw_model():
         owner="Ponder Stibbons;Mustrum Ridcully",
         owner_group="faculty",
         investigator="p.stibbons@uu.am",
-        source_folder="/hex/source62",
+        source_folder=RemotePath("/hex/source62"),
         creation_location="ANK/UU",
         shared_with=["librarian", "hicks"],
     )
@@ -312,7 +313,7 @@ def test_make_raw_model():
         owner="Ponder Stibbons;Mustrum Ridcully",
         ownerGroup="faculty",
         principalInvestigator="p.stibbons@uu.am",
-        sourceFolder="/hex/source62",
+        sourceFolder=RemotePath("/hex/source62"),
         type=DatasetType.RAW,
         history=[],
         isPublished=False,
@@ -335,7 +336,7 @@ def test_make_derived_model():
         owner="Ponder Stibbons;Mustrum Ridcully",
         owner_group="faculty",
         investigator="p.stibbons@uu.am",
-        source_folder="/hex/source62",
+        source_folder=RemotePath("/hex/source62"),
         meta={"weight": {"value": 5.23, "unit": "kg"}},
         input_datasets=[PID(pid="623-122")],
         used_software=["scitacean", "magick"],
@@ -346,7 +347,7 @@ def test_make_derived_model():
         owner="Ponder Stibbons;Mustrum Ridcully",
         ownerGroup="faculty",
         investigator="p.stibbons@uu.am",
-        sourceFolder="/hex/source62",
+        sourceFolder=RemotePath("/hex/source62"),
         type=DatasetType.DERIVED,
         history=[],
         isPublished=False,
@@ -379,7 +380,7 @@ def test_make_raw_model_raises_if_derived_field_set(field, data):
         owner="Mustrum Ridcully",
         owner_group="faculty",
         investigator="p.stibbons@uu.am",
-        source_folder="/hex/source62",
+        source_folder=RemotePath("/hex/source62"),
     )
     setattr(dset, field.name, data.draw(st.from_type(field.type)))
     with pytest.raises(ValueError):
@@ -404,7 +405,7 @@ def test_make_derived_model_raises_if_raw_field_set(field, data):
         owner="Ponder Stibbons",
         owner_group="faculty",
         investigator="p.stibbons@uu.am",
-        source_folder="/hex/source62",
+        source_folder=RemotePath("/hex/source62"),
         input_datasets=[PID(pid="623-122")],
         used_software=["scitacean", "magick"],
     )
@@ -422,7 +423,7 @@ def test_email_validation(field):
         owner="Mustrum Ridcully",
         owner_group="faculty",
         investigator="p.stibbons@uu.am",
-        source_folder="/hex/source62",
+        source_folder=RemotePath("/hex/source62"),
     )
     setattr(dset, field, "not-an-email")
     with pytest.raises(pydantic.ValidationError):
@@ -445,7 +446,7 @@ def test_orcid_validation_valid(good_orcid):
         owner="Jan-Lukas Wynen",
         owner_group="ess",
         investigator="jan-lukas.wynen@ess.eu",
-        source_folder="/hex/source62",
+        source_folder=RemotePath("/hex/source62"),
         orcid_of_owner=good_orcid,
     )
     assert dset.make_model().orcidOfOwner == good_orcid
@@ -468,7 +469,7 @@ def test_orcid_validation_missing_url(bad_orcid):
         owner="Jan-Lukas Wynen",
         owner_group="ess",
         investigator="jan-lukas.wynen@ess.eu",
-        source_folder="/hex/source62",
+        source_folder=RemotePath("/hex/source62"),
         orcid_of_owner=bad_orcid,
     )
     with pytest.raises(pydantic.ValidationError):

--- a/tests/download_test.py
+++ b/tests/download_test.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2022 Scitacean contributors (https://github.com/SciCatProject/scitacean)
 # @author Jan-Lukas Wynen
 import hashlib
-import os
 import re
 from pathlib import Path
 from typing import Union
@@ -11,6 +10,7 @@ import pytest
 from dateutil.parser import parse as parse_date
 
 from scitacean import PID, Client, Dataset, DatasetType, File, IntegrityError
+from scitacean.filesystem import RemotePath
 from scitacean.model import DataFile, OrigDatablock, RawDataset
 from scitacean.testing.transfer import FakeFileTransfer
 
@@ -37,7 +37,7 @@ def dataset_and_files(data_files):
         ownerGroup="faculty",
         pid=PID(prefix="UU.000", pid="5125.ab.663.8c9f"),
         principalInvestigator="m.ridcully@uu.am",
-        sourceFolder="/src/stibbons/774",
+        sourceFolder=RemotePath("/src/stibbons/774"),
         type=DatasetType.RAW,
     )
     block = OrigDatablock(
@@ -49,8 +49,7 @@ def dataset_and_files(data_files):
     )
     dset = Dataset.from_models(dataset_model=model, orig_datablock_models=[block])
     return dset, {
-        os.path.join(dset.source_folder, name): content
-        for name, content in data_files[1].items()
+        dset.source_folder / name: content for name, content in data_files[1].items()
     }
 
 
@@ -197,7 +196,7 @@ def test_download_files_ignores_checksum_if_alg_is_none(fs, dataset_and_files):
     client = Client.without_login(
         url="/",
         file_transfer=FakeFileTransfer(
-            fs=fs, files={os.path.join(dataset.source_folder, "file.txt"): content}
+            fs=fs, files={dataset.source_folder / "file.txt": content}
         ),
     )
     # Does not raise
@@ -221,7 +220,7 @@ def test_download_files_detects_bad_checksum(fs, dataset_and_files):
     client = Client.without_login(
         url="/",
         file_transfer=FakeFileTransfer(
-            fs=fs, files={os.path.join(dataset.source_folder, "file.txt"): content}
+            fs=fs, files={dataset.source_folder / "file.txt": content}
         ),
     )
     with pytest.raises(IntegrityError):
@@ -245,7 +244,7 @@ def test_download_files_detects_bad_size(fs, dataset_and_files):
     client = Client.without_login(
         url="/",
         file_transfer=FakeFileTransfer(
-            fs=fs, files={os.path.join(dataset.source_folder, "file.txt"): content}
+            fs=fs, files={dataset.source_folder / "file.txt": content}
         ),
     )
     with pytest.raises(IntegrityError):

--- a/tests/filesystem.py
+++ b/tests/filesystem.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022 Scitacean contributors (https://github.com/SciCatProject/scitacean)
+# @author Jan-Lukas Wynen
+import hashlib
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from scitacean.filesystem import (
+    RemotePath,
+    checksum_of_file,
+    file_modification_time,
+    file_size,
+)
+
+
+def test_remote_path_creation_and_str():
+    assert str(RemotePath("/mnt/data/folder/file.txt")) == "/mnt/data/folder/file.txt"
+    assert str(RemotePath("dir/image.png")) == "dir/image.png"
+    assert str(RemotePath("data.nxs")) == "data.nxs"
+    assert str(RemotePath(RemotePath("source/events.h5"))) == "source/events.h5"
+
+
+def test_remote_path_init_requires_path_like():
+    with pytest.raises(TypeError):
+        RemotePath(6133)  # type: ignore
+    with pytest.raises(TypeError):
+        RemotePath(["folder", "file.dat"])  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "types", ((RemotePath, RemotePath), (RemotePath, str), (str, RemotePath))
+)
+def test_remote_path_eq(types):
+    ta, tb = types
+    assert ta("/source/data.csv") == tb("/source/data.csv")
+
+
+@pytest.mark.parametrize(
+    "types", ((RemotePath, RemotePath), (RemotePath, str), (str, RemotePath))
+)
+def test_remote_path_neq(types):
+    ta, tb = types
+    assert ta("/source/data.csv") != tb("/host/dir/song.mp3")
+
+
+@pytest.mark.parametrize(
+    "types", ((RemotePath, RemotePath), (RemotePath, str), (str, RemotePath))
+)
+def test_remote_path_join(types):
+    ta, tb = types
+    assert ta("/source/123") / tb("file.data") == RemotePath("/source/123/file.data")
+    assert ta("/source/123/") / tb("file.data") == RemotePath("/source/123/file.data")
+    assert ta("/source/123") / tb("/file.data") == RemotePath("/source/123/file.data")
+    assert ta("/source/123/") / tb("/file.data") == RemotePath("/source/123/file.data")
+
+
+@pytest.mark.parametrize(
+    "types", ((RemotePath, RemotePath), (RemotePath, str), (str, RemotePath))
+)
+def test_remote_path_join_url(types):
+    ta, tb = types
+    assert ta("https://server.eu") / tb("1234-abcd/data.txt") == RemotePath(
+        "https://server.eu/1234-abcd/data.txt"
+    )
+    assert ta("https://server.eu/") / tb("1234-abcd/data.txt") == RemotePath(
+        "https://server.eu/1234-abcd/data.txt"
+    )
+    assert ta("https://server.eu") / tb("/1234-abcd/data.txt") == RemotePath(
+        "https://server.eu/1234-abcd/data.txt"
+    )
+    assert ta("https://server.eu/") / tb("/1234-abcd/data.txt") == RemotePath(
+        "https://server.eu/1234-abcd/data.txt"
+    )
+
+
+def test_remote_path_name():
+    assert RemotePath("table.csv").name == "table.csv"
+    assert RemotePath("README").name == "README"
+    assert RemotePath("path/").name == "path"
+    assert RemotePath("dir/folder/file1.txt").name == "file1.txt"
+
+
+def test_remote_path_suffix():
+    assert RemotePath("file.txt").suffix == ".txt"
+    assert RemotePath("folder/image.png").suffix == ".png"
+    assert RemotePath("dir/table.txt.csv").suffix == ".csv"
+    assert RemotePath("archive.tz/data.dat").suffix == ".dat"
+    assert RemotePath("location.dir/file").suffix is None
+    assert RemotePath("source/file").suffix is None

--- a/tests/upload_test.py
+++ b/tests/upload_test.py
@@ -105,11 +105,12 @@ def test_upload_uploads_files_to_source_folder(client, dataset):
 
     with client.file_transfer.connect_for_upload(finalized.pid) as con:
         source_dir = con.source_dir
+
     assert (
-        client.file_transfer.files[source_dir + "file.nxs"] == b"contents of file.nxs"
+        client.file_transfer.files[source_dir / "file.nxs"] == b"contents of file.nxs"
     )
     assert (
-        client.file_transfer.files[source_dir + "the_log_file.log"]
+        client.file_transfer.files[source_dir / "the_log_file.log"]
         == b"this is a log file"
     )
 

--- a/tools/model-generation/spec/dataset.yml
+++ b/tools/model-generation/spec/dataset.yml
@@ -153,7 +153,7 @@ fields:
     description: Absolute file path on file server containing the files of this dataset, e.g. /some/path/to/sourcefolder. In case of a single file dataset, e.g. HDF5 data, it contains the path up to, but excluding the filename.
     model_name: sourceFolder
     required: true
-    type: str
+    type: RemotePath
   - name: source_folder_host
     description: DNS host name of file server hosting source_folder, optionally including protocol e.g. [protocol://]fileserver1.example.com
     model_name: sourceFolderHost

--- a/tools/model-generation/templates/dataset.py.template
+++ b/tools/model-generation/templates/dataset.py.template
@@ -14,6 +14,7 @@ from typing import Any, Callable, Dict, Generator, List, Literal, Optional, Unio
 import dateutil.parser
 
 from .datablock import OrigDatablockProxy
+from .filesystem import RemotePath
 from .model import (
     DatasetLifecycle,
     DatasetType,

--- a/tools/model-generation/templates/model.py.template
+++ b/tools/model-generation/templates/model.py.template
@@ -6,12 +6,14 @@
 """Pydantic models to encode data for communication with SciCat."""
 
 import enum
+import os
 from datetime import datetime
 from typing import Dict, List, Optional
 
 import pydantic
 
 from ._internal.orcid import is_valid_orcid
+from .filesystem import RemotePath
 from .pid import PID
 
 
@@ -26,7 +28,7 @@ class DatasetType(str, enum.Enum):
 class BaseModel(pydantic.BaseModel):
     class Config:
         extra = pydantic.Extra.forbid
-        json_encoders = {PID: lambda v: str(v)}
+        json_encoders = {PID: lambda v: str(v), RemotePath: lambda v: os.fspath(v)}
 
 
 $models


### PR DESCRIPTION
`os.path.join` uses the path separator of the system it is running on, i.e. backslash on Windows. This leads to bad paths on the fileserver. The new `RemotePath` class always uses forward slashes. All uses of paths on the remote should not use this class.
Note that this can technically be incorrect if the remote is a Windows system. But that is unlikely to ever happen.

The changes to `tests/common/backend.py` were not meant to be in this PR but I based this branch on the wrong branch and can't be asked to remove those commits :) 

@SimonHeybrock can you have a look?