### PR TITLE
Do not require investigator to be an email

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -41,6 +41,7 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 * The ``remote_base_path`` argument of ``SSHFileTransfer`` has been replaced with ``source_folder`` which may now contain format specifiers.
+* ``Dataset.investigator`` is no longer required to be an email address as this does not match common usage.
 
 Bugfixes
 ~~~~~~~~

--- a/src/scitacean/_dataset_fields.py
+++ b/src/scitacean/_dataset_fields.py
@@ -210,7 +210,7 @@ class DatasetFields:
         ),
         Field(
             name="investigator",
-            description="Email of the (principal) investigator. The string may contain a list of emails, which should then be separated by semicolons.",
+            description="(Principal) investigator. Can be one or more names or emails separated by semicolons.",
             read_only=False,
             required_by_derived=True,
             required_by_raw=True,
@@ -751,7 +751,7 @@ class DatasetFields:
 
     @property
     def investigator(self) -> Optional[str]:
-        """Email of the (principal) investigator. The string may contain a list of emails, which should then be separated by semicolons."""
+        """(Principal) investigator. Can be one or more names or emails separated by semicolons."""
         return self._fields["investigator"]  # type: ignore[no-any-return]
 
     @investigator.setter

--- a/src/scitacean/model.py
+++ b/src/scitacean/model.py
@@ -136,7 +136,7 @@ class DerivedDataset(Ownable):
     validationStatus: Optional[str]
     version: Optional[str]
 
-    @pydantic.validator("contactEmail", "investigator", "ownerEmail")
+    @pydantic.validator("contactEmail", "ownerEmail")
     def _validate_emails(cls, value: Any) -> Any:
         return _validate_emails(value)
 
@@ -195,7 +195,7 @@ class RawDataset(Ownable):
     validationStatus: Optional[str]
     version: Optional[str]
 
-    @pydantic.validator("contactEmail", "principalInvestigator", "ownerEmail")
+    @pydantic.validator("contactEmail", "ownerEmail")
     def _validate_emails(cls, value: Any) -> Any:
         return _validate_emails(value)
 

--- a/src/scitacean/testing/strategies.py
+++ b/src/scitacean/testing/strategies.py
@@ -66,7 +66,6 @@ def _scientific_metadata_strategy(
 
 
 _SPECIAL_FIELDS = {
-    "investigator": _email_field_strategy,
     "contact_email": _email_field_strategy,
     "owner_email": _email_field_strategy,
     "orcid_of_owner": _orcid_field_strategy,

--- a/tests/dataset_fields_test.py
+++ b/tests/dataset_fields_test.py
@@ -411,7 +411,7 @@ def test_make_derived_model_raises_if_raw_field_set(field, data):
         dset.make_model()
 
 
-@pytest.mark.parametrize("field", ("contact_email", "investigator", "owner_email"))
+@pytest.mark.parametrize("field", ("contact_email", "owner_email"))
 def test_email_validation(field):
     dset = Dataset(
         type="raw",

--- a/tools/model-generation/spec/dataset.yml
+++ b/tools/model-generation/spec/dataset.yml
@@ -50,11 +50,10 @@ fields:
     type: List[PID]
     used: [ derived ]
   - name: investigator
-    description: Email of the (principal) investigator. The string may contain a list of emails, which should then be separated by semicolons.
+    description: (Principal) investigator. Can be one or more names or emails separated by semicolons.
     model_name: { derived: investigator, raw: principalInvestigator }
     required: true
     type: str
-    validation: emails
   - name: is_published
     default: false
     description: Indicate whether the dataset is publicly available.


### PR DESCRIPTION
Fixes #54

As discussed offline, the investigator is usually not specified as an email and the backend does not require it to be.