### PR TITLE
Make dataset.pid mutable

### DIFF
--- a/src/scitacean/_dataset_fields.py
+++ b/src/scitacean/_dataset_fields.py
@@ -378,7 +378,7 @@ class DatasetFields:
         Field(
             name="pid",
             description="Persistent identifier for datasets.",
-            read_only=True,
+            read_only=False,
             required_by_derived=False,
             required_by_raw=False,
             type=PID,
@@ -522,6 +522,7 @@ class DatasetFields:
         *,
         type: Union[DatasetType, Literal["derived", "raw"]],
         creation_time: Optional[Union[datetime, str]] = None,
+        pid: Optional[Union[str, PID]] = None,
         access_groups: Optional[List[str]] = None,
         classification: Optional[str] = None,
         contact_email: Optional[str] = None,
@@ -554,7 +555,6 @@ class DatasetFields:
         used_software: Optional[List[str]] = None,
         validation_status: Optional[str] = None,
         checksum_algorithm: Optional[str] = "md5",
-        _pid: Optional[Union[str, PID]] = None,
         _read_only: Optional[Dict[str, Any]] = None,
         _orig_datablocks: Optional[List[OrigDatablockProxy]] = None,
     ):
@@ -571,7 +571,7 @@ class DatasetFields:
         self._fields = {
             "creation_time": _parse_datetime(creation_time),
             "history": _apply_default(_read_only.get("history"), None, list),
-            "pid": PID.parse(_pid) if isinstance(_pid, str) else _pid,
+            "pid": PID.parse(pid) if isinstance(pid, str) else pid,
             "type": DatasetType(type),
             "access_groups": _apply_default(access_groups, None, None),
             "classification": _apply_default(classification, None, None),
@@ -641,6 +641,11 @@ class DatasetFields:
     def pid(self) -> Optional[PID]:
         """Persistent identifier for datasets."""
         return self._fields["pid"]  # type: ignore[no-any-return]
+
+    @pid.setter
+    def pid(self, pid: Optional[Union[PID, str]]) -> None:
+        """Persistent identifier for datasets."""
+        self._fields["pid"] = None if pid is None else PID.parse(pid)
 
     @property
     def creation_time(self) -> datetime:

--- a/src/scitacean/dataset.py
+++ b/src/scitacean/dataset.py
@@ -56,7 +56,7 @@ class Dataset(DatasetFields):
         return cls(
             type=dataset_model.type,
             creation_time=dataset_model.creationTime,
-            _pid=dataset_model.pid,
+            pid=dataset_model.pid,
             _orig_datablocks=[]
             if not orig_datablock_models
             else [
@@ -226,7 +226,6 @@ class Dataset(DatasetFields):
                 field.name: get_val(replacements, field.name)
                 for field in Dataset.fields(read_only=False)
             },
-            "_pid": read_only.pop("pid"),
         }
         if replacements or _read_only:
             raise TypeError(

--- a/src/scitacean/testing/strategies.py
+++ b/src/scitacean/testing/strategies.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional
 from email_validator import EmailNotValidError, validate_email
 from hypothesis import strategies as st
 
-from scitacean import PID, Dataset, DatasetType
+from scitacean import Dataset, DatasetType
 from scitacean._internal.orcid import orcid_checksum
 
 
@@ -107,18 +107,11 @@ def datasets(
             if field.name != "type"
         }
 
-    try:
-        pid = make_fixed_arg("pid")
-        del fixed["pid"]
-    except KeyError:
-        pid = st.builds(PID)
-
     kwargs = make_args(read_only=False)
     read_only_arg = st.fixed_dictionaries(make_args(read_only=True))
     return st.builds(
         Dataset,
         type=st.just(dataset_type),
         _read_only=read_only_arg,
-        _pid=pid,
         **kwargs,
     )

--- a/tests/upload_test.py
+++ b/tests/upload_test.py
@@ -92,6 +92,15 @@ def test_upload_without_files_creates_dataset(client, derived_dataset_model):
         client.scicat.get_orig_datablocks(finalized.pid)
 
 
+def test_upload_uses_given_pid(client, derived_dataset_model):
+    derived_dataset_model.pid = "my-custom-id"
+    dataset = Dataset.from_models(
+        dataset_model=derived_dataset_model, orig_datablock_models=None
+    )
+    finalized = client.upload_new_dataset_now(dataset)
+    assert "my-custom-id" in str(finalized.pid)
+
+
 def test_upload_creates_dataset_and_datablock(client, dataset):
     finalized = client.upload_new_dataset_now(dataset)
     assert client.datasets[finalized.pid] == finalized.make_model()

--- a/tests/util/formatter.py
+++ b/tests/util/formatter.py
@@ -14,7 +14,7 @@ def test_dataset_formatter_uses_dataset_fields():
 
 
 def test_dataset_formatter_can_access_attrs_of_fields():
-    dset = Dataset(type="raw", _pid="prefix/actual-id")
+    dset = Dataset(type="raw", pid="prefix/actual-id")
     formatted = DatasetPathFormatter().format("{pid.pid}", dset)
     assert formatted == "actual-id"
 

--- a/tools/model-generation/spec/dataset.yml
+++ b/tools/model-generation/spec/dataset.yml
@@ -126,7 +126,6 @@ fields:
   - name: pid
     description: Persistent identifier for datasets.
     manual: true
-    read_only: true
     type: PID
   - name: proposal_id
     description: Identifier for the proposal that the dataset was produced for.

--- a/tools/model-generation/templates/dataset.py.template
+++ b/tools/model-generation/templates/dataset.py.template
@@ -73,9 +73,9 @@ class DatasetFields:
         *,
         type: Union[DatasetType, Literal["derived", "raw"]],
         creation_time: Optional[Union[datetime, str]] = None,
+        pid: Optional[Union[str, PID]] = None,
         $field_init_args,
         checksum_algorithm: Optional[str] = "md5",
-        _pid: Optional[Union[str, PID]] = None,
         _read_only: Optional[Dict[str, Any]] = None,
         _orig_datablocks: Optional[List[OrigDatablockProxy]] = None,
     ):
@@ -92,7 +92,7 @@ class DatasetFields:
         self._fields = {
             "creation_time": _parse_datetime(creation_time),
             "history": _apply_default(_read_only.get("history"), None, list),
-            "pid": PID.parse(_pid) if isinstance(_pid, str) else _pid,
+            "pid": PID.parse(pid) if isinstance(pid, str) else pid,
             "type": DatasetType(type),
 $field_dict_construction
         }
@@ -127,6 +127,11 @@ $field_dict_construction
     def pid(self) -> Optional[PID]:
         """Persistent identifier for datasets."""
         return self._fields["pid"]  # type: ignore[no-any-return]
+
+    @pid.setter
+    def pid(self, pid: Optional[Union[PID, str]]) -> None:
+        """Persistent identifier for datasets."""
+        self._fields["pid"] = None if pid is None else PID.parse(pid)
 
     @property
     def creation_time(self) -> datetime:


### PR DESCRIPTION
As requested. This allows people to set `dataset.pid` themselves and the client will use it when uploading a dataset.