### PR TITLE
Better scientific metadata format for ESS-style encoding

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -41,6 +41,8 @@ Security
 Features
 ~~~~~~~~
 
+* Better HTML formatting of ESS-style scientific metadata.
+
 Breaking changes
 ~~~~~~~~~~~~~~~~
 

--- a/src/scitacean/_html_repr/__init__.py
+++ b/src/scitacean/_html_repr/__init__.py
@@ -68,7 +68,7 @@ def _format_metadata(dset: Dataset) -> str:
 def _format_metadata_value(value: Any) -> str:
     if _has_value_unit_encoding(value):
         if (unit := value.get("unit")) is not None:
-            return f"{html.escape(value['value'])} [{html.escape(unit)}]"
+            return f"{html.escape(str(value['value']))} [{html.escape(str(unit))}]"
         else:
             return html.escape(str(value["value"]))
 

--- a/src/scitacean/_html_repr/__init__.py
+++ b/src/scitacean/_html_repr/__init__.py
@@ -59,10 +59,36 @@ def _format_metadata(dset: Dataset) -> str:
     return "\n".join(
         template.substitute(
             name=html.escape(str(name)),
-            value=html.escape(str(value)),
+            value=_format_metadata_value(value),
         )
         for name, value in dset.meta.items()
     )
+
+
+def _format_metadata_value(value: Any) -> str:
+    if _has_value_unit_encoding(value):
+        if (unit := value.get("unit")) is not None:
+            return f"{html.escape(value['value'])} [{html.escape(unit)}]"
+        else:
+            return html.escape(str(value["value"]))
+
+    return html.escape(str(value))
+
+
+# ESS uses these keys for all scientific metadata.
+# If the metadata uses only these keys, format it more nicely.
+# Otherwise, fall back to showing the item's str.
+_VALUE_UNIT_KEYS = {"value", "unit", "valueSI", "unitSI"}
+
+
+def _has_value_unit_encoding(meta_value: Any):
+    if (
+        isinstance(meta_value, dict)
+        and "value" in meta_value
+        and not (meta_value.keys() - _VALUE_UNIT_KEYS)
+    ):
+        return True
+    return False
 
 
 @dataclass

--- a/src/scitacean/_html_repr/styles/dataset.css
+++ b/src/scitacean/_html_repr/styles/dataset.css
@@ -141,9 +141,13 @@ table.cean-metadata {
     text-align: left !important;
 }
 
-.cean-metadata-name,
+.cean-metadata-name {
+    width: 30%;
+    text-align: left !important;
+}
+
 .cean-metadata-value {
-    width: 50%;
+    width: 70%;
     text-align: left !important;
 }
 


### PR DESCRIPTION
Fixes  #80

For simplicity, this does not conditionally add a unit column. Instead, if shows the unit in bracket notation if the data is encoded in the expected way. Items that are encoded differently (have extra keys, not 'value' key, or are not a dict) are shown as before.

![metadata-repr](https://user-images.githubusercontent.com/11393224/228878266-1fe354d4-29ae-4eb8-8755-5ecb6cffb74f.png)
