### PR TITLE
Add experimental ScicatClient.query_datasets

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -41,6 +41,8 @@ Security
 Features
 ~~~~~~~~
 
+* Added experimental :meth:`client.ScicatClient.query_datasets` for querying datasets by field.
+
 Breaking changes
 ~~~~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,11 +98,11 @@ extend-include = ["*.ipynb"]
 extend-exclude = [".*", "__pycache__", "build", "dist", "venv"]
 
 [tool.ruff.lint]
-select = ["B", "C4", "D", "DTZ", "E", "F", "G", "I", "FBT003", "PERF", "PGH", "PT", "PYI", "RUF", "S", "T20", "W"]
+select = ["B", "C4", "D", "DTZ", "E", "F", "G", "I", "FBT003", "PERF", "PGH", "PT", "PYI", "RUF", "S", "T20", "UP", "W"]
 ignore = [
     "D105",  # most magic methods don't need docstrings as their purpose is always the same
     "E741", "E742", "E743",  # do not use names ‘l’, ‘O’, or ‘I’; they are not a problem with a proper font
-    "UP038",  # does not seem to work and leads to slower code
+    "UP038",  # leads to slower code
     # Conflict with ruff format, see
     # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
     "COM812", "COM819", "D206", "D300", "E111", "E114", "E117", "ISC001", "ISC002", "Q000", "Q001", "Q002", "Q003", "W191",

--- a/src/scitacean/client.py
+++ b/src/scitacean/client.py
@@ -768,7 +768,10 @@ class ScicatClient:
 
         .. code-block:: python
 
-            scicat_client.query_datasets({'proposalId': 'abc.123', 'name': 'ds name'})
+            scicat_client.query_datasets({
+                'proposalId': 'abc.123',
+                'datasetName': 'ds name'
+            })
 
         Return only the newest 5 datasets for proposal ``bc.123``:
 

--- a/src/scitacean/client.py
+++ b/src/scitacean/client.py
@@ -781,12 +781,12 @@ class ScicatClient:
             )
         """
         # Use a pydantic model to support serializing custom types to JSON.
-        params_model = pydantic.create_model(
+        params_model = pydantic.create_model(  # type: ignore[call-overload]
             "QueryParams", **{key: (type(field), ...) for key, field in fields.items()}
         )
         params = {"fields": params_model(**fields).model_dump_json()}
 
-        limits = {}
+        limits: dict[str, Union[str, int]] = {}
         if order is not None:
             limits["order"] = order
         if limit is not None:

--- a/src/scitacean/client.py
+++ b/src/scitacean/client.py
@@ -786,7 +786,7 @@ class ScicatClient:
         )
         params = {"fields": params_model(**fields).model_dump_json()}
 
-        limits: dict[str, Union[str, int]] = {}
+        limits: dict[str, str | int] = {}
         if order is not None:
             limits["order"] = order
         if limit is not None:

--- a/tests/client/query_client_test.py
+++ b/tests/client/query_client_test.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 SciCat Project (https://github.com/SciCatProject/scitacean)
+
+import pytest
+from dateutil.parser import parse as parse_datetime
+
+from scitacean import Client, DatasetType, RemotePath, model
+from scitacean.testing.backend import skip_if_not_backend
+from scitacean.testing.backend.config import SciCatAccess
+
+UPLOAD_DATASETS = {
+    "raw1": model.UploadRawDataset(
+        ownerGroup="PLACEHOLDER",
+        accessGroups=["uu", "faculty"],
+        contactEmail="ponder.stibbons@uu.am",
+        creationTime=parse_datetime("2004-06-13T01:45:28.100Z"),
+        datasetName="dataset 1",
+        numberOfFiles=0,
+        numberOfFilesArchived=0,
+        owner="PLACEHOLDER",
+        sourceFolder=RemotePath("/hex/raw1"),
+        type=DatasetType.RAW,
+        principalInvestigator="investigator 1",
+        creationLocation="UU",
+        proposalId="p0124",
+    ),
+    "raw2": model.UploadRawDataset(
+        ownerGroup="PLACEHOLDER",
+        accessGroups=["uu", "faculty"],
+        contactEmail="ponder.stibbons@uu.am",
+        creationTime=parse_datetime("2004-06-14T14:00:30Z"),
+        datasetName="dataset 2",
+        numberOfFiles=0,
+        numberOfFilesArchived=0,
+        owner="PLACEHOLDER",
+        sourceFolder=RemotePath("/hex/raw2"),
+        type=DatasetType.RAW,
+        principalInvestigator="investigator 2",
+        creationLocation="UU",
+        proposalId="p0124",
+    ),
+    "raw3": model.UploadRawDataset(
+        ownerGroup="PLACEHOLDER",
+        accessGroups=["uu", "faculty"],
+        contactEmail="ponder.stibbons@uu.am",
+        creationTime=parse_datetime("2004-06-10T00:13:13Z"),
+        datasetName="dataset 3",
+        numberOfFiles=0,
+        numberOfFilesArchived=0,
+        owner="PLACEHOLDER",
+        sourceFolder=RemotePath("/hex/raw3"),
+        type=DatasetType.RAW,
+        principalInvestigator="investigator 1",
+        creationLocation="UU",
+        proposalId="p0124",
+    ),
+    "raw4": model.UploadRawDataset(
+        ownerGroup="PLACEHOLDER",
+        accessGroups=["uu", "faculty"],
+        contactEmail="ponder.stibbons@uu.am",
+        creationTime=parse_datetime("2005-11-03T21:56:02Z"),
+        datasetName="dataset 1",
+        numberOfFiles=0,
+        numberOfFilesArchived=0,
+        owner="PLACEHOLDER",
+        sourceFolder=RemotePath("/hex/raw4"),
+        type=DatasetType.RAW,
+        principalInvestigator="investigator X",
+        creationLocation="UU",
+    ),
+    "derived1": model.UploadDerivedDataset(
+        ownerGroup="PLACEHOLDER",
+        accessGroups=["uu", "faculty"],
+        contactEmail="ponder.stibbons@uu.am",
+        creationTime=parse_datetime("2004-10-02T08:47:33Z"),
+        datasetName="dataset 1",
+        numberOfFiles=0,
+        numberOfFilesArchived=0,
+        owner="PLACEHOLDER",
+        sourceFolder=RemotePath("/hex/derived1"),
+        type=DatasetType.DERIVED,
+        investigator="investigator 1",
+        inputDatasets=[],
+        usedSoftware=["scitacean"],
+    ),
+    "derived2": model.UploadDerivedDataset(
+        ownerGroup="PLACEHOLDER",
+        accessGroups=["uu", "faculty"],
+        contactEmail="ponder.stibbons@uu.am",
+        creationTime=parse_datetime("2004-10-14T09:18:58Z"),
+        datasetName="derived dataset 2",
+        numberOfFiles=0,
+        numberOfFilesArchived=0,
+        owner="PLACEHOLDER",
+        sourceFolder=RemotePath("/hex/derived2"),
+        type=DatasetType.DERIVED,
+        investigator="investigator 1",
+        inputDatasets=[],
+        usedSoftware=["scitacean"],
+    ),
+}
+SEED = {}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def seed_database(request: pytest.FixtureRequest, scicat_access: SciCatAccess) -> None:
+    skip_if_not_backend(request)
+
+    client = Client.from_credentials(
+        url=scicat_access.url,
+        **scicat_access.user.credentials,  # type: ignore[arg-type]
+    )
+    for key, dset in UPLOAD_DATASETS.items():
+        dset.ownerGroup = scicat_access.user.group
+        dset.owner = scicat_access.user.username
+        SEED[key] = client.scicat.create_dataset_model(dset)
+
+
+def test_query_dataset_multiple_by_single_field(real_client, seed_database):
+    datasets = real_client.scicat.query_datasets({"proposalId": "p0124"})
+    actual = {ds.pid: ds for ds in datasets}
+    expected = {SEED[key].pid: SEED[key] for key in ("raw1", "raw2", "raw3")}
+    assert actual == expected
+
+
+def test_query_dataset_no_match(real_client, seed_database):
+    datasets = real_client.scicat.query_datasets({"owner": "librarian"})
+    assert not datasets
+
+
+def test_query_dataset_multiple_by_multiple_fields(real_client, seed_database):
+    datasets = real_client.scicat.query_datasets(
+        {"proposalId": "p0124", "principalInvestigator": "investigator 1"},
+    )
+    actual = {ds.pid: ds for ds in datasets}
+    expected = {SEED[key].pid: SEED[key] for key in ("raw1", "raw3")}
+    assert actual == expected
+
+
+def test_query_dataset_multiple_by_derived_field(real_client, seed_database):
+    datasets = real_client.scicat.query_datasets(
+        {"investigator": "investigator 1"},
+    )
+    actual = {ds.pid: ds for ds in datasets}
+    expected = {SEED[key].pid: SEED[key] for key in ("derived1", "derived2")}
+    assert actual == expected
+
+
+def test_query_dataset_uses_conjunction_of_fields(real_client, seed_database):
+    datasets = real_client.scicat.query_datasets(
+        {"proposalId": "p0124", "investigator": "investigator X"},
+    )
+    assert not datasets
+
+
+def test_query_dataset_can_use_custom_type(real_client, seed_database):
+    datasets = real_client.scicat.query_datasets(
+        {"sourceFolder": RemotePath("/hex/raw4")},
+    )
+    expected = [SEED["raw4"]]
+    assert datasets == expected
+
+
+def test_query_dataset_set_order(real_client, seed_database):
+    datasets = real_client.scicat.query_datasets(
+        {"proposalId": "p0124"},
+        order="creationTime:desc",
+    )
+    # This test uses a list to check the order
+    expected = [SEED[key] for key in ("raw2", "raw1", "raw3")]
+    assert datasets == expected
+
+
+def test_query_dataset_limit_ascending_creation_time(real_client, seed_database):
+    datasets = real_client.scicat.query_datasets(
+        {"proposalId": "p0124"},
+        limit=2,
+        order="creationTime:asc",
+    )
+    actual = {ds.pid: ds for ds in datasets}
+    expected = {SEED[key].pid: SEED[key] for key in ("raw1", "raw3")}
+    assert actual == expected
+
+
+def test_query_dataset_limit_descending_creation_time(real_client, seed_database):
+    datasets = real_client.scicat.query_datasets(
+        {"proposalId": "p0124"},
+        limit=2,
+        order="creationTime:desc",
+    )
+    actual = {ds.pid: ds for ds in datasets}
+    expected = {SEED[key].pid: SEED[key] for key in ("raw1", "raw2")}
+    assert actual == expected
+
+
+def test_query_dataset_limit_needs_order(real_client, seed_database):
+    with pytest.raises(ValueError, match="limit"):
+        real_client.scicat.query_datasets(
+            {"proposalId": "p0124"},
+            limit=2,
+        )
+
+
+def test_query_dataset_all(real_client, seed_database):
+    datasets = real_client.scicat.query_datasets({})
+    actual = {ds.pid: ds for ds in datasets}
+    # We cannot test `datasets` directly because there are other datasets
+    # in the database from other tests.
+    for ds in SEED.values():
+        assert actual[ds.pid] == ds

--- a/tests/client/query_client_test.py
+++ b/tests/client/query_client_test.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 SciCat Project (https://github.com/SciCatProject/scitacean)
 
+from typing import Union
+
 import pytest
 from dateutil.parser import parse as parse_datetime
 
@@ -8,7 +10,9 @@ from scitacean import Client, DatasetType, RemotePath, model
 from scitacean.testing.backend import skip_if_not_backend
 from scitacean.testing.backend.config import SciCatAccess
 
-UPLOAD_DATASETS = {
+UPLOAD_DATASETS: dict[
+    str, Union[model.UploadDerivedDataset, model.UploadRawDataset]
+] = {
     "raw1": model.UploadRawDataset(
         ownerGroup="PLACEHOLDER",
         accessGroups=["uu", "faculty"],


### PR DESCRIPTION
First attempt at solving #177

This is meant as a prototype to try out a simple query syntax. As the docstring says, I am open to changing the interface in the future. But this version should be enough to get some users going with querying and we can improve when we have experience with it and a better idea of where SciCat is headed.

I only added it in the low-level `ScicatClient` because of the questions raised in #177 about the performance implications of building `Dataset` objects.