### PR TITLE
Pin backend version 4.8.0

### DIFF
--- a/src/scitacean/testing/backend/docker-compose-backend-template.yaml
+++ b/src/scitacean/testing/backend/docker-compose-backend-template.yaml
@@ -16,7 +16,7 @@ services:
       - "27017:27017"
 
   scicat:
-    image: ghcr.io/scicatproject/backend-next:stable
+    image: ghcr.io/scicatproject/backend-next:v4.8.0
     container_name: scitacean-test-scicat
     depends_on:
       - mongodb


### PR DESCRIPTION
This should keep tests and CI stable when the backend get changed. But we need a way to test with the latest backend version as well. This should be part of the backend tests in some form.