### PR TITLE
Setup for integration testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   formatting:
     name: Formatting and static analysis
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -24,7 +24,7 @@ jobs:
   type-checking:
     name: Type checking
     needs: formatting
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -40,10 +40,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - {python: '3.13', os: ubuntu-22.04, tox: py313-full}
-          - {python: '3.12', os: ubuntu-22.04, tox: py312-full}
-          - {python: '3.11', os: ubuntu-22.04, tox: py311-full}
-          - {python: '3.10', os: ubuntu-22.04, tox: py310-full}
+          - {python: '3.13', os: ubuntu-24.04, tox: py313-full}
+          - {python: '3.12', os: ubuntu-24.04, tox: py312-full}
+          - {python: '3.11', os: ubuntu-24.04, tox: py311-full}
+          - {python: '3.10', os: ubuntu-24.04, tox: py310-full}
           - {python: '3.10', os: macos-14, tox: py310}
           - {python: '3.10', os: windows-2022, tox: py310}
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,8 @@ jobs:
       - run: tox -e mypy
 
   tests:
-    name: Tests ${{ matrix.os }} ${{ matrix.tox }}
+    name: Tests
     needs: formatting
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
@@ -47,16 +46,12 @@ jobs:
           - {python: '3.10', os: ubuntu-22.04, tox: py310-full}
           - {python: '3.10', os: macos-14, tox: py310}
           - {python: '3.10', os: windows-2022, tox: py310}
-    steps:
-      - run: sudo apt install --yes docker-compose
-        if: ${{ contains(matrix.os, 'ubuntu') }}
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-      - run: python -m pip install --upgrade pip
-      - run: python -m pip install -r requirements/ci.txt
-      - run: tox -e ${{ matrix.tox }}
+    uses: ./.github/workflows/test.yml
+    with:
+      os-variant: ${{ matrix.os }}
+      python-version: ${{ matrix.python }}
+      tox-env: ${{ matrix.tox }}
+    secrets: inherit
 
   docs:
     needs: tests

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   docs:
     name: Build documentation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - run: sudo apt install --yes pandoc
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_wheels:
     name: Wheels
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
   upload_packages:
     name: Deploy packages
     needs: [build_wheels]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment:
       name: release
       url: https://pypi.org/p/scitacean/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,10 @@ on:
         default: ''
         type: string
         description: 'Git ref to checkout'
+      backend-version:
+        default: ''
+        type: string
+        description: 'SciCat backend version, e.g., "v4.8.0"'
   workflow_call:
     inputs:
       os-variant:
@@ -29,6 +33,9 @@ on:
         default: 'test'
         type: string
       checkout-ref:
+        default: ''
+        type: string
+      backend-version:
         default: ''
         type: string
 
@@ -48,3 +55,6 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: python -m pip install -r requirements/ci.txt
       - run: tox -e ${{ inputs.tox-env }}
+        if: ${{ !inputs.backend-version }}
+      - run: tox -e ${{ inputs.tox-env }} -- ${{ inputs.backend-version }}
+        if: ${{ inputs.backend-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,50 @@
+name: Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      os-variant:
+        default: 'ubuntu-24.04'
+        type: string
+        description: 'Operating system'
+      python-version:
+        type: string
+        description: 'Python interpreter version'
+      tox-env:
+        default: 'test'
+        type: string
+        description: 'Tox environment to run'
+      checkout-ref:
+        default: ''
+        type: string
+        description: 'Git ref to checkout'
+  workflow_call:
+    inputs:
+      os-variant:
+        default: 'ubuntu-24.04'
+        type: string
+      python-version:
+        type: string
+      tox-env:
+        default: 'test'
+        type: string
+      checkout-ref:
+        default: ''
+        type: string
+
+jobs:
+  tests:
+    name: Tests ${{ inputs.os-variant }} ${{ inputs.tox-env }}
+    runs-on: ${{ inputs.os-variant }}
+    steps:
+      - run: sudo apt install --yes docker-compose
+        if: ${{ contains(inputs.os-variant, 'ubuntu') }}
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkout-ref }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -r requirements/ci.txt
+      - run: tox -e ${{ inputs.tox-env }}

--- a/docs/user-guide/testing.ipynb
+++ b/docs/user-guide/testing.ipynb
@@ -390,13 +390,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "29",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import pytest\n",
-    "from scitacean.testing.backend import add_pytest_option as add_backend_option\n",
+    "from scitacean.testing.backend import add_pytest_options as add_backend_options\n",
     "\n",
     "\n",
     "pytest_plugins = (\n",
@@ -404,7 +402,7 @@
     ")\n",
     "\n",
     "def pytest_addoption(parser: pytest.Parser) -> None:\n",
-    "    add_backend_option(parser)"
+    "    add_backend_options(parser)"
    ]
   },
   {
@@ -413,7 +411,7 @@
    "metadata": {},
    "source": [
     "The backend will only be launched when the corresponding command line option is given.\n",
-    "By default, this is `--backend-tests` but it can be changed via the `option` argument of `add_pytest_option`.\n",
+    "By default, this is `--backend-tests` but it can be changed via the `option` argument of `add_pytest_options`.\n",
     "\n",
     "### Use SciCat in tests\n",
     "\n",
@@ -424,9 +422,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "31",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def test_something_with_scicat(require_scicat_backend):\n",

--- a/src/scitacean/testing/backend/__init__.py
+++ b/src/scitacean/testing/backend/__init__.py
@@ -61,7 +61,7 @@ If a test requires a backend but wants to construct a client manually, use
 .. autosummary::
    :toctree: ../functions
 
-   add_pytest_option
+   add_pytest_options
    backend_enabled
    configure
    skip_if_not_backend
@@ -77,10 +77,10 @@ from ._backend import (
     stop_backend,
     wait_until_backend_is_live,
 )
-from ._pytest_helpers import add_pytest_option, backend_enabled, skip_if_not_backend
+from ._pytest_helpers import add_pytest_options, backend_enabled, skip_if_not_backend
 
 __all__ = [
-    "add_pytest_option",
+    "add_pytest_options",
     "backend_enabled",
     "config",
     "configure",

--- a/src/scitacean/testing/backend/_pytest_helpers.py
+++ b/src/scitacean/testing/backend/_pytest_helpers.py
@@ -7,15 +7,15 @@ import pytest
 _COMMAND_LINE_OPTION: str | None = None
 
 
-def add_pytest_option(parser: pytest.Parser, option: str = "--backend-tests") -> None:
-    """Add a command-line option to pytest to toggle backend tests.
+def add_pytest_options(parser: pytest.Parser, option: str = "--backend-tests") -> None:
+    """Add command-line options to pytest to control backend tests.
 
     Parameters
     ----------
     parser:
         Pytest's command-line argument parser.
     option:
-        Name of the command-line option.
+        Name of the command-line option to toggle backend tests.
     """
     parser.addoption(
         option,
@@ -25,6 +25,12 @@ def add_pytest_option(parser: pytest.Parser, option: str = "--backend-tests") ->
     )
     global _COMMAND_LINE_OPTION
     _COMMAND_LINE_OPTION = option
+
+    parser.addoption(
+        "--scitacean-backend-version",
+        default=None,
+        help="Specify a version for the SciCat backend",
+    )
 
 
 def skip_if_not_backend(request: pytest.FixtureRequest) -> None:

--- a/src/scitacean/testing/backend/docker-compose-backend-template.yaml
+++ b/src/scitacean/testing/backend/docker-compose-backend-template.yaml
@@ -3,8 +3,8 @@
 # before it can be used by docker compose.
 #
 # The images are based on the CI setup of the SciCat backend
-# and the latest stable package:
-# https://github.com/SciCatProject/scicat-backend-next/pkgs/container/backend-next/97880429?tag=stable
+# and a released package of the version configured in pyproject.toml:
+# https://github.com/SciCatProject/scicat-backend-next/pkgs/container/backend-next/versions
 #
 # See https://scicatproject.github.io/documentation/Development/v4.x/backend/configuration.html
 # for a list of all env variables.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@
 import hypothesis
 import pytest
 
-from scitacean.testing.backend import add_pytest_option as add_backend_option
+from scitacean.testing.backend import add_pytest_options as add_backend_options
 from scitacean.testing.sftp import add_pytest_option as add_sftp_option
 
 pytest_plugins = (
@@ -26,5 +26,5 @@ hypothesis.settings.register_profile(
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
-    add_backend_option(parser)
+    add_backend_options(parser)
     add_sftp_option(parser)

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ isolated_build = true
 [testenv]
 deps = -r requirements/test.txt
 commands =
-    full: python -m pytest --backend-tests --sftp-tests
-    !full: python -m pytest
+    full: python -m pytest --backend-tests --sftp-tests {posargs}
+    !full: python -m pytest {posargs}
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs


### PR DESCRIPTION
This should help us set up integration tests that get started by upstream projects (e.g., the backend).