### PR TITLE
Make tox-env argument required

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ on:
         type: string
         description: 'Python interpreter version'
       tox-env:
-        default: 'test'
         type: string
         description: 'Tox environment to run'
       checkout-ref:


### PR DESCRIPTION
This was an oversight. It should always be required because the default value was not a correct tox env.