### PR TITLE
Add Dataset.add_attachment

### DIFF
--- a/docs/user-guide/uploading.ipynb
+++ b/docs/user-guide/uploading.ipynb
@@ -32,6 +32,7 @@
    "outputs": [],
    "source": [
     "from scitacean.testing.docs import setup_fake_client\n",
+    "\n",
     "client = setup_fake_client()"
    ]
   },
@@ -324,14 +325,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from scitacean import Attachment, Thumbnail\n",
-    "\n",
-    "dset.attachments.append(\n",
-    "    Attachment(\n",
-    "        caption=\"Scitacean logo\",\n",
-    "        owner_group=dset.owner_group,\n",
-    "        thumbnail=Thumbnail.load_file(\"./logo.png\"),\n",
-    "    )\n",
+    "dset.add_attachment(\n",
+    "    caption=\"Scitacean logo\",\n",
+    "    thumbnail=\"./logo.png\",\n",
     ")\n",
     "dset.attachments[0]"
    ]
@@ -341,7 +337,8 @@
    "id": "24",
    "metadata": {},
    "source": [
-    "We used `Thumbnail.load_file` because it properly encodes the file for SciCat.\n",
+    "`Dataset.add_attachment` can load an image from a file and properly encode it for SciCat.\n",
+    "We could also use a more manual approach and construct `scitacean.Attachment` and `scitacean.Thumbnail` objects ourselves and append them to `dset.attachments`.\n",
     "\n",
     "When we then upload the dataset, the client automatically uploads all attachments as well.\n",
     "Note that this creates a new dataset in SciCat.\n",
@@ -390,6 +387,7 @@
     "# This cell is hidden.\n",
     "# It should remove *only* files and directories created by this notebook.\n",
     "import shutil\n",
+    "\n",
     "shutil.rmtree(\"data\", ignore_errors=True)"
    ]
   }

--- a/src/scitacean/file.py
+++ b/src/scitacean/file.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import dataclasses
+import os
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
@@ -65,7 +66,7 @@ class File:
     @classmethod
     def from_local(
         cls,
-        path: str | Path,
+        path: str | os.PathLike[str],
         *,
         remote_path: str | RemotePath | None = None,
         remote_uid: str | None = None,
@@ -182,7 +183,7 @@ class File:
         model: DownloadDataFile,
         *,
         checksum_algorithm: str | None = None,
-        local_path: str | Path | None = None,
+        local_path: str | os.PathLike[str] | None = None,
     ) -> File:
         """Construct a new file object from a SciCat download model.
 
@@ -202,7 +203,7 @@ class File:
         """
         return File(
             checksum_algorithm=checksum_algorithm,
-            local_path=Path(local_path) if isinstance(local_path, str) else local_path,
+            local_path=Path(local_path) if local_path is not None else None,
             remote_path=RemotePath(model.path),  # type: ignore[arg-type]
             remote_gid=model.gid,
             remote_perm=model.perm,
@@ -381,7 +382,7 @@ class File:
             **{key: val for key, val in args.items() if val is not None},  # type: ignore[arg-type]
         )
 
-    def downloaded(self, *, local_path: str | Path) -> File:
+    def downloaded(self, *, local_path: str | os.PathLike[str]) -> File:
         """Return new file metadata after a download.
 
         Assumes that the input file exists on remote.

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -11,7 +11,7 @@ from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 from pyfakefs.fake_filesystem import FakeFilesystem
 
-from scitacean import PID, Dataset, DatasetType, File, RemotePath, model
+from scitacean import PID, Dataset, DatasetType, File, RemotePath, Thumbnail, model
 from scitacean.testing import strategies as sst
 from scitacean.testing.client import process_uploaded_dataset
 
@@ -435,7 +435,7 @@ def test_attachments_initialized_in_from_download_models(
     ]
 
 
-def test_can_add_attachment() -> None:
+def test_can_append_attachment() -> None:
     dataset = Dataset(type="raw", owner_group="dset-owner")
     dataset.attachments.append(
         model.Attachment(
@@ -477,6 +477,61 @@ def test_can_assign_attachments() -> None:
         model.Attachment(
             caption="Attachment 2",
             owner_group="other_owner",
+        )
+    ]
+
+
+def test_add_attachment_from_file(fs: FakeFilesystem) -> None:
+    fs.create_file("fingers.jpg", contents=b"jal2l9vun2")
+
+    dataset = Dataset(
+        type="raw",
+        owner_group="owner",
+        proposal_id="dset-proposal",
+        access_groups=["dset-access"],
+    )
+    dataset.add_attachment(
+        caption="The attachment",
+        thumbnail="fingers.jpg",
+        access_groups=["attachment-access"],
+        sample_id="attachment-sample",
+    )
+    assert dataset.attachments == [
+        model.Attachment(
+            caption="The attachment",
+            owner_group="owner",
+            thumbnail=Thumbnail.load_file("fingers.jpg"),
+            proposal_id="dset-proposal",
+            access_groups=["attachment-access"],
+            sample_id="attachment-sample",
+        )
+    ]
+
+
+def test_add_attachment_from_thumbnail(fs: FakeFilesystem) -> None:
+    fs.create_file("fingers.jpg", contents=b"jal2l9vun2")
+    thumbnail = Thumbnail.load_file("fingers.jpg")
+
+    dataset = Dataset(
+        type="raw",
+        owner_group="owner",
+        proposal_id="dset-proposal",
+        access_groups=["dset-access"],
+    )
+    dataset.add_attachment(
+        caption="The attachment",
+        thumbnail=thumbnail,
+        access_groups=["attachment-access"],
+        sample_id="attachment-sample",
+    )
+    assert dataset.attachments == [
+        model.Attachment(
+            caption="The attachment",
+            owner_group="owner",
+            thumbnail=thumbnail,
+            proposal_id="dset-proposal",
+            access_groups=["attachment-access"],
+            sample_id="attachment-sample",
         )
     ]
 


### PR DESCRIPTION
The existing method for adding attachments is very flexible but also complicated to use. One has to know both `Attachment` and `Thumbnail` classes and know how to construct them. This new method should make the most common cases much simpler.