### PR TITLE
Fall back from link upload to next file transfer

### DIFF
--- a/src/scitacean/transfer/link.py
+++ b/src/scitacean/transfer/link.py
@@ -225,8 +225,10 @@ class LinkFileTransfer:
             "`LinkFileTransfer` cannot be used for uploading files. "
             "If you have direct access to the file server, consider either "
             "copying the files into place or writing them directly to the "
-            "'remote folder'."
+            "'remote folder'. See also scitacean.transfer.copy.CopyFileTransfer.",
         )
+        # This is needed to make this function a context manager:
+        yield LinkUploadConnection(source_folder=self.source_folder)  # type: ignore[unreachable]
 
 
 __all__ = ["LinkDownloadConnection", "LinkFileTransfer", "LinkUploadConnection"]

--- a/src/scitacean/transfer/select.py
+++ b/src/scitacean/transfer/select.py
@@ -151,7 +151,7 @@ class SelectFileTransfer:
                     # a different transfer if the actual download / upload fails
                     # but only if connecting fails.
                     connection = connection_manager.__enter__()
-                except RuntimeError as error:
+                except (RuntimeError, NotImplementedError) as error:
                     errors.append(error)
                     continue
                 success = True

--- a/tests/transfer/link_test.py
+++ b/tests/transfer/link_test.py
@@ -88,7 +88,8 @@ def test_link_transfer_cannot_upload() -> None:
     ds = Dataset(type="raw", source_folder=RemotePath("/data/upload"))
     linker = LinkFileTransfer()
     with pytest.raises(NotImplementedError):
-        linker.connect_for_upload(ds, cast(RemotePath, ds.source_folder))
+        with linker.connect_for_upload(ds, cast(RemotePath, ds.source_folder)):
+            ...
 
 
 def test_link_transfer_raises_if_file_does_not_exist(


### PR DESCRIPTION
`SelectFileTransfer` did not fall back to the next transfer if a `LinkFileTransfer` was used for uploading. This PR fixes that.