### PR TITLE
Use absolute path for link.

### DIFF
--- a/src/scitacean/transfer/link.py
+++ b/src/scitacean/transfer/link.py
@@ -41,7 +41,7 @@ class LinkDownloadConnection:
                 "access to the file server. Consider using a different file transfer.",
                 remote_path=remote,
             )
-        local.symlink_to(remote_path)
+        local.symlink_to(remote_path.absolute())
 
 
 class LinkUploadConnection:


### PR DESCRIPTION
I had this problem when I tried to use link transfer.
I didn't really understand it well, but apparently it happens when the original file is in the `./` path and the target file is also relative to `./`.... 

But apparently we can avoid it by using absolute path.

Can we do that...?

![image](https://github.com/user-attachments/assets/67abf713-4186-43f4-9327-18075298ca64)
