### PR TITLE
Allow more low-level access to dataset fields

### DIFF
--- a/src/scitacean/_dataset_fields.py
+++ b/src/scitacean/_dataset_fields.py
@@ -55,6 +55,14 @@ def _parse_techniques(arg: Iterable[str | Technique] | None) -> list[Technique] 
     return [t if isinstance(t, Technique) else find_technique(t) for t in arg]
 
 
+def _parse_input_datasets(arg: Iterable[PID | str] | None) -> list[PID]:
+    if arg is None:
+        return []
+    if isinstance(arg, str):
+        arg = [arg]  # not technically supposed to work but permitted by type hint
+    return [PID.parse(pid) for pid in arg]
+
+
 def _validate_checksum_algorithm(algorithm: str | None) -> str | None:
     if algorithm is None:
         return algorithm
@@ -457,7 +465,7 @@ class DatasetBase:
         data_quality_metrics: int | None = None,
         description: str | None = None,
         end_time: datetime | None = None,
-        input_datasets: list[PID] | None = None,
+        input_datasets: Iterable[PID | str] | None = None,
         instrument_group: str | None = None,
         instrument_ids: list[str] | None = None,
         is_published: bool | None = None,
@@ -499,7 +507,7 @@ class DatasetBase:
         self._data_quality_metrics = data_quality_metrics
         self._description = description
         self._end_time = end_time
-        self._input_datasets = input_datasets or []
+        self._input_datasets = _parse_input_datasets(input_datasets)
         self._instrument_group = instrument_group
         self._instrument_ids = instrument_ids
         self._is_published = is_published

--- a/src/scitacean/dataset.py
+++ b/src/scitacean/dataset.py
@@ -504,32 +504,44 @@ class Dataset(DatasetBase):
             )
         return existing
 
+    def make_upload_fields(self) -> dict[str, Any]:
+        """Return a dict with the fields for uploading a dataset.
+
+        Returns
+        -------
+        :
+            The writable fields of this dataset.
+            Nested models are converted such that the following is valid:
+
+            .. code-block:: python
+
+                model.UploadDataset(**dataset.make_upload_fields())
+        """
+        special = ("relationships", "techniques", "input_datasets", "used_software")
+
+        return {
+            "numberOfFiles": self.number_of_files,
+            "numberOfFilesArchived": self.number_of_files_archived,
+            "size": self.size,
+            "packedSize": self.packed_size,
+            "scientificMetadata": self._meta or None,
+            "techniques": convert_user_to_upload_model(self.techniques),
+            "relationships": convert_user_to_upload_model(self.relationships),
+            "inputDatasets": self.input_datasets or [],
+            "usedSoftware": self.used_software or [],
+            **{
+                field.scicat_name: value
+                for field in self.fields(read_only=False)
+                if field.name not in special
+                and (value := getattr(self, field.name)) is not None
+            },
+        }
+
     def make_upload_model(self) -> UploadDataset:
         """Construct a SciCat upload model from self."""
         # Datablocks are not included here because they are handled separately
         # by make_datablock_upload_models and their own endpoints.
-        special = ("relationships", "techniques", "input_datasets", "used_software")
-        return UploadDataset(
-            numberOfFiles=self.number_of_files,
-            numberOfFilesArchived=self.number_of_files_archived,
-            size=self.size,
-            packedSize=self.packed_size,
-            scientificMetadata=self._meta or None,
-            techniques=convert_user_to_upload_model(  # type: ignore[arg-type]
-                self.techniques
-            ),
-            relationships=convert_user_to_upload_model(  # type: ignore[arg-type]
-                self.relationships
-            ),
-            inputDatasets=self.input_datasets or [],
-            usedSoftware=self.used_software or [],
-            **{
-                field.scicat_name: value
-                for field in self.fields()
-                if field.name not in special
-                and (value := getattr(self, field.name)) is not None
-            },
-        )
+        return UploadDataset(**self.make_upload_fields())
 
     def make_datablock_upload_models(self) -> DatablockUploadModels:
         """Build models for all contained (orig) datablocks.


### PR DESCRIPTION
The new `Dataset.make_upload_fields` helps the widget serialise data. And the change to support input datasets from strings helps parse inputs produced by the widget.