### PR TITLE
Construct custom techniques from labels

### DIFF
--- a/src/scitacean/ontology/__init__.py
+++ b/src/scitacean/ontology/__init__.py
@@ -93,11 +93,10 @@ def _lookup_label(label: str) -> Technique:
             "https://pan-ontologies.github.io/PaNET/index-en.html"
         )
     # else: len(found) == 0
-    raise ValueError(
-        f"Unknown technique label: '{label}'\n"
-        "See the ExPaNDS experimental technique ontology for allowed labels at "
-        "https://pan-ontologies.github.io/PaNET/index-en.html"
-    )
+    # We need to set a PID for every technique. Using `pid=label` here means that
+    # the id is predicable and techniques can be compared while there should be
+    # no collisions between unrelated techniques.
+    return Technique(pid=label, name=label)
 
 
 def _lookup_iri(iri: str) -> Technique:

--- a/src/scitacean/ontology/__init__.py
+++ b/src/scitacean/ontology/__init__.py
@@ -70,8 +70,8 @@ def find_technique(label_or_iri: str) -> Technique:
     ValueError
         If the label or IRI is not found in the ontology.
     """
-    if _is_iri(label_or_iri):
-        return _lookup_iri(label_or_iri)
+    if iri := _try_normalize_iri(label_or_iri):
+        return _lookup_iri(iri)
     return _lookup_label(label_or_iri)
 
 
@@ -112,11 +112,15 @@ def _lookup_iri(iri: str) -> Technique:
     return Technique(pid=iri, name=label)
 
 
-_IRI_REGEX = re.compile(r"^https?://purl\.org/pan-science/PaNET/PaNET\d+$")
+_IRI_REGEX = re.compile(r"^\s*(https?://purl\.org/pan-science/PaNET/)?(PaNET\d+)\s*$")
 
 
-def _is_iri(iri: str) -> bool:
-    return bool(_IRI_REGEX.match(iri))
+def _try_normalize_iri(raw: str) -> str | None:
+    m = _IRI_REGEX.match(raw)
+    if not m:
+        return None
+    base = m.group(2)
+    return f"http://purl.org/pan-science/PaNET/{base}"
 
 
 __all__ = ["expands_techniques", "find_technique"]

--- a/tests/client/dataset_client_test.py
+++ b/tests/client/dataset_client_test.py
@@ -9,7 +9,7 @@ import pytest
 
 from scitacean import PID, Client, Dataset, RemotePath, ScicatCommError
 from scitacean.client import ScicatClient
-from scitacean.model import UploadDataset
+from scitacean.model import Technique, UploadDataset
 from scitacean.testing.backend import config as backend_config
 from scitacean.testing.backend.seed import (
     INITIAL_DATASETS,
@@ -164,3 +164,23 @@ def test_dataset_with_orig_datablock_roundtrip(client: Client) -> None:
     assert downloaded.owner == ds.owner
     assert downloaded.size == ds.size
     assert downloaded.number_of_files == ds.number_of_files
+
+
+def test_upload_dataset_with_different_techniques(client: Client) -> None:
+    ds = Dataset.from_download_model(
+        INITIAL_DATASETS["raw"].model_copy(
+            update={"origdatablocks": INITIAL_ORIG_DATABLOCKS["raw"]}
+        )
+    ).as_new()
+    ds.techniques = [
+        "http://purl.org/pan-science/PaNET/PaNET01189",
+        "PaNET2013002",
+        "neutron powder diffraction",  # PaNET01100
+        Technique(pid="custom-id", name="My technique"),  # custom w/ id
+        "extra special",  # custom w/o technique
+    ]
+
+    finalized = client.upload_new_dataset_now(ds)
+    downloaded = client.get_dataset(finalized.pid)
+
+    assert downloaded.techniques == ds.techniques

--- a/tests/dataset_fields_test.py
+++ b/tests/dataset_fields_test.py
@@ -458,14 +458,10 @@ def test_technique_set_label() -> None:
         pid="http://purl.org/pan-science/PaNET/PaNET01100",
         name="neutron powder diffraction",
     )
-    Technique(
-        name="neutron powder diffraction",
-        pid="http://purl.org/pan-science/PaNET/PaNET01100",
-    )
     assert dset.techniques == [expected]
 
 
-def test_technique_set_invalid_label_raises_value_error() -> None:
+def test_technique_set_id() -> None:
     dset = Dataset(
         type="raw",
         contact_email="mail.person@sci.uni",
@@ -474,6 +470,28 @@ def test_technique_set_invalid_label_raises_value_error() -> None:
         owner_group="ess",
         principal_investigators=["mail.person@sci.uni"],
         source_folder=RemotePath("/hex/source62"),
+        techniques=["PaNET01100"],
     )
-    with pytest.raises(ValueError, match="Unknown technique"):
-        dset.techniques = ["bad technique"]
+    expected = Technique(
+        pid="http://purl.org/pan-science/PaNET/PaNET01100",
+        name="neutron powder diffraction",
+    )
+    assert dset.techniques == [expected]
+
+
+def test_technique_set_invalid_label_creates_custom_technique() -> None:
+    dset = Dataset(
+        type="raw",
+        contact_email="mail.person@sci.uni",
+        creation_time="2142-04-02T16:44:56",
+        owner="Mustrum Ridcully",
+        owner_group="ess",
+        principal_investigators=["mail.person@sci.uni"],
+        source_folder=RemotePath("/hex/source62"),
+        techniques=["my technique"],
+    )
+    expected = Technique(
+        pid="my technique",
+        name="my technique",
+    )
+    assert dset.techniques == [expected]

--- a/tests/ontology_test.py
+++ b/tests/ontology_test.py
@@ -55,8 +55,17 @@ def test_can_look_up_technique_by_alternative_label() -> None:
     assert alternative3 == expected
 
 
-def test_can_look_up_technique_by_full_iri() -> None:
+def test_can_look_up_technique_by_full_iri_http() -> None:
     technique = ontology.find_technique("http://purl.org/pan-science/PaNET/PaNET01239")
+    expected = model.Technique(
+        pid="http://purl.org/pan-science/PaNET/PaNET01239",
+        name="neutron reflectometry",
+    )
+    assert technique == expected
+
+
+def test_can_look_up_technique_by_full_iri_https() -> None:
+    technique = ontology.find_technique("https://purl.org/pan-science/PaNET/PaNET01239")
     expected = model.Technique(
         pid="http://purl.org/pan-science/PaNET/PaNET01239",
         name="neutron reflectometry",
@@ -76,3 +85,9 @@ def test_can_look_up_technique_by_short_iri() -> None:
 def test_lookup_rejects_ambiguous_label() -> None:
     with pytest.raises(ValueError, match="multiple techniques"):
         ontology.find_technique("diffraction")
+
+
+def test_lookup_falls_back_for_unknown_label() -> None:
+    technique = ontology.find_technique("unknown-label")
+    expected = model.Technique(pid="unknown-label", name="unknown-label")
+    assert technique == expected

--- a/tests/ontology_test.py
+++ b/tests/ontology_test.py
@@ -55,8 +55,17 @@ def test_can_look_up_technique_by_alternative_label() -> None:
     assert alternative3 == expected
 
 
-def test_can_look_up_technique_by_iri() -> None:
+def test_can_look_up_technique_by_full_iri() -> None:
     technique = ontology.find_technique("http://purl.org/pan-science/PaNET/PaNET01239")
+    expected = model.Technique(
+        pid="http://purl.org/pan-science/PaNET/PaNET01239",
+        name="neutron reflectometry",
+    )
+    assert technique == expected
+
+
+def test_can_look_up_technique_by_short_iri() -> None:
+    technique = ontology.find_technique("PaNET01239")
     expected = model.Technique(
         pid="http://purl.org/pan-science/PaNET/PaNET01239",
         name="neutron reflectometry",


### PR DESCRIPTION
The ontology does not cover all required techniques. So users will need to define their own. This change makes that easier by allowing simple strings instead or requiring users to build `Technique` objects themselves.